### PR TITLE
Fix AttributeError in add_build_to_beta_group

### DIFF
--- a/appstoreconnect/api.py
+++ b/appstoreconnect/api.py
@@ -360,8 +360,7 @@ class Api:
 
 	def add_build_to_beta_group(self, beta_group_id, build_id):
 		post_data = {'data': [{ 'id': build_id, 'type': 'builds'}]}
-		payload = self._api_call(BASE_API + "/v1/betaGroups/" + beta_group_id + "/relationships/builds", HttpMethod.POST, post_data)
-		return BetaGroup(payload.get('data'), {})
+		self._api_call(BASE_API + "/v1/betaGroups/" + beta_group_id + "/relationships/builds", HttpMethod.POST, post_data)
 
 	# App Resources
 	def read_app_information(self, app_ip):


### PR DESCRIPTION
Hi, thanks for the cool library!

`add_build_to_beta_group` raises AttributeError for me:

```
Traceback (most recent call last):
  File "/home/ilya/tmp/appstore/test.py", line 30, in <module>
    api.add_build_to_beta_group(group.id, build_2_15_42.id)
  File "/home/ilya/tmp/appstore/venv/lib/python3.8/site-packages/appstoreconnect/api.py", line 365, in add_build_to_beta_group
    return BetaGroup(payload.get('data'), {})
AttributeError: 'Response' object has no attribute 'get'
```

But it does its job: build successfully added to the group.

Seems like crash is due to code trying to get payload from API response. But [corresponding doc page](https://developer.apple.com/documentation/appstoreconnectapi/add_builds_to_a_beta_group#http-body) says this method returns `204 No Content` on success. 204 response code can't bear any payload. Probably API has changed or something.

So I propose to remove the code that expecting BetaGroup to be returned from `/v1/betaGroups/{id}/relationships/builds`.